### PR TITLE
 [SERVER-OAuth] Passport GitHub OAuth 적용

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -4,6 +4,10 @@ const path = require('path');
 const cookieParser = require('cookie-parser');
 const logger = require('morgan');
 
+const session = require('express-session');
+const passport = require('passport');
+const GitHubStrategy = require('passport-github2').Strategy;
+
 const indexRouter = require('./routes/index');
 const usersRouter = require('./routes/users');
 
@@ -15,21 +19,80 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
+// 세션 관련
+passport.serializeUser(function (user, done) {
+  done(null, user);
+});
+passport.deserializeUser(function (obj, done) {
+  done(null, obj);
+});
+
+// .env로 빼야할 부분
+const GITHUB_CLIENT_ID = '';
+const GITHUB_CLIENT_SECRET = '';
+
+passport.use(
+  new GitHubStrategy(
+    {
+      clientID: GITHUB_CLIENT_ID,
+      clientSecret: GITHUB_CLIENT_SECRET,
+      callbackURL: 'http://localhost:3000/auth/github/callback',
+    },
+    function (accessToken, refreshToken, profile, done) {
+      console.log(accessToken);
+      console.log(profile);
+      // User.findOrCreate({ githubId: profile.username }, function (err, user) {
+      //   return done(err, user);
+      // });
+      const err = null;
+      const user = profile;
+      const info = '인증 성공';
+      done(err, user, info);
+    }
+  )
+);
+
 app.use('/', indexRouter);
 app.use('/users', usersRouter);
 
-// catch 404 and forward to error handler
+//----------------------------------------------------------------------------------
+// router로 빼야하는 부분
+// secret을 dotenv로 빼기
+app.use(
+  session({ secret: 'keyboard cat', resave: false, saveUninitialized: false })
+);
+
+app.use(passport.initialize());
+app.use(passport.session());
+
+app.get(
+  '/auth/github',
+  passport.authenticate('github', { scope: ['user:email'] })
+);
+
+app.get(
+  '/auth/github/callback',
+  passport.authenticate('github', { failureRedirect: '/login' }),
+  function (req, res) {
+    res.redirect('/');
+  }
+);
+
+app.get('/logout', function (req, res) {
+  req.logout();
+  res.redirect('/');
+});
+
+//----------------------------------------------------------------------------------
+
 app.use(function (req, res, next) {
   next(createError(404));
 });
 
-// error handler
 app.use(function (err, req, res, next) {
-  // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};
 
-  // render the error page
   res.status(err.status || 500);
   return;
 });

--- a/server/package.json
+++ b/server/package.json
@@ -10,8 +10,11 @@
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
     "express": "~4.16.1",
+    "express-session": "^1.17.1",
     "http-errors": "~1.6.3",
-    "morgan": "~1.9.1"
+    "morgan": "~1.9.1",
+    "passport": "^0.4.1",
+    "passport-github2": "^0.1.12"
   },
   "devDependencies": {
     "eslint": "^7.12.1",


### PR DESCRIPTION
1. **인증을 위한 github OAuth 추가**

Passport GitHub 인증을 하는 라우터입니다.
```jsx
app.get(
  '/auth/github',
  passport.authenticate('github', { scope: ['user:email'] })
);

app.get(
  '/auth/github/callback',
  passport.authenticate('github', { failureRedirect: '/login' }),
  function (req, res) {
    res.redirect('/');
  }
);
```

2. **github OAuth 의 사용을 위한 passport 전략 구성**

GitHubStrategy는 'passport-github2'의 Strategy를 설정하는 클래스입니다.
```jsx
passport.use(
  new GitHubStrategy(
    {
      clientID: GITHUB_CLIENT_ID,
      clientSecret: GITHUB_CLIENT_SECRET,
      callbackURL: 'http://localhost:3000/auth/github/callback',
    },
    function (accessToken, refreshToken, profile, done) {
      console.log(accessToken);
      console.log(profile);
      // User.findOrCreate({ githubId: profile.username }, function (err, user) {
      //   return done(err, user);
      // });
      const err = null;
      const user = profile;
      const info = '인증 성공';
      done(err, user, info);
    }
  )
);
```

3. **Access Token 을 저장 & 관리를 위한 express-session 구성**

GitHub에서 access token을 발급 받아, session에 저장 관리합니다. 
```jsx
const session = require('express-session');

passport.serializeUser(function (user, done) {
  done(null, user);
});
passport.deserializeUser(function (obj, done) {
  done(null, obj);
});

app.use(
  session({ secret: 'keyboard cat', resave: false, saveUninitialized: false })
);

app.use(passport.initialize());
app.use(passport.session());
```
