### PR TITLE
[CLIENT-LOGINVIEW] GitHub OAuth Login View완성

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.21.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },
@@ -22,6 +23,7 @@
     "axios": "^0.21.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
+    "babel-polyfill": "^6.26.0",
     "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^5.0.0",
     "eslint": "^7.12.1",

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "@babel/preset-react": "^7.12.1",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
+    "babel-polyfill": "^6.26.0",
     "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^5.0.0",
     "eslint": "^7.12.1",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.21.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },

--- a/client/src/views/loginView/index.jsx
+++ b/client/src/views/loginView/index.jsx
@@ -4,6 +4,7 @@ import imgSrc from '@assets/svg/github-icon.svg';
 import Input from '@components/loginView/input';
 
 const loginView = () => {
+  const urlForGitHubOAuth = 'http://localhost:5000/api/auth/github/';
   const [Id, setId] = useState('');
   const [Password, setPassword] = useState('');
 
@@ -15,20 +16,25 @@ const loginView = () => {
     setPassword(e.currentTarget.value);
   };
 
-  console.log(Id);
-
   const onSubmitHandler = e => {
     e.preventDefault();
-
-    console.log(Id);
-    console.log(Password);
-    const body = {};
-
+    // const body = { id: Id, password: Password };
     /*
       Axios.post('/api/users/login', body).then(response => {
-
       })
       */
+  };
+
+  const onGitHubLoginHandler = async e => {
+    e.preventDefault();
+    console.log('test');
+    // try {
+    //   const body = { id: Id, password: Password };
+    //   const result = await Axios.post(urlForGitHubOAuth, body, { withCredentials: true });
+    //   console.log(result);
+    // } catch (error) {
+    //   console.log(error);
+    // }
   };
 
   return (
@@ -50,7 +56,7 @@ const loginView = () => {
               </button>
             </div>
           </form>
-          <a className="gitHubLogin" href="#">
+          <a className="gitHubLogin" onClick={onGitHubLoginHandler}>
             Sign with GitHub
             <img className="gitHubMark" src={imgSrc} />
           </a>

--- a/client/src/views/loginView/index.jsx
+++ b/client/src/views/loginView/index.jsx
@@ -2,9 +2,10 @@ import React, { useState, useRef } from 'react';
 import './style.scss';
 import imgSrc from '@assets/svg/github-icon.svg';
 import Input from '@components/loginView/input';
+import axios from 'axios';
 
 const loginView = () => {
-  const urlForGitHubOAuth = 'http://localhost:5000/api/auth/github/';
+  const urlForGitHubOAuth = '/api/auth/github/';
   const [Id, setId] = useState('');
   const [Password, setPassword] = useState('');
 
@@ -18,23 +19,16 @@ const loginView = () => {
 
   const onSubmitHandler = e => {
     e.preventDefault();
-    // const body = { id: Id, password: Password };
-    /*
-      Axios.post('/api/users/login', body).then(response => {
-      })
-      */
   };
 
   const onGitHubLoginHandler = async e => {
     e.preventDefault();
-    console.log('test');
-    // try {
-    //   const body = { id: Id, password: Password };
-    //   const result = await Axios.post(urlForGitHubOAuth, body, { withCredentials: true });
-    //   console.log(result);
-    // } catch (error) {
-    //   console.log(error);
-    // }
+    try {
+      const result = await axios.get(urlForGitHubOAuth);
+      console.log(result.data);
+    } catch (error) {
+      console.log(error);
+    }
   };
 
   return (
@@ -67,26 +61,3 @@ const loginView = () => {
 };
 
 export default loginView;
-
-/*
-<div className="loginContainer">
-      <h1>이슈 트래커</h1>
-      <div className="loginBox">
-        <div>
-          아이디
-          <input id="id" type="text" />
-        </div>
-        <div>
-          비밀번호
-          <input id="password" type="password" />
-        </div>
-        <div>
-          <a href="#">로그인</a>
-          <a href="#">회원가입</a>
-        </div>
-        <div>
-          <a href="#">GitHub 회원가입</a>
-        </div>
-      </div>
-    </div>
-    */

--- a/client/src/views/loginView/index.jsx
+++ b/client/src/views/loginView/index.jsx
@@ -3,9 +3,12 @@ import './style.scss';
 import imgSrc from '@assets/svg/github-icon.svg';
 import Input from '@components/loginView/input';
 
+const urlForGitHubOAuth = '/api/auth/github/';
+const clientUrl = 'http://localhost:3000/issues-list';
+
 const loginView = () => {
-  const [Id, setId] = useState('');
-  const [Password, setPassword] = useState('');
+  const [id, setId] = useState('');
+  const [password, setPassword] = useState('');
 
   const onIdHandler = e => {
     setId(e.currentTarget.value);
@@ -15,20 +18,8 @@ const loginView = () => {
     setPassword(e.currentTarget.value);
   };
 
-  console.log(Id);
-
   const onSubmitHandler = e => {
     e.preventDefault();
-
-    console.log(Id);
-    console.log(Password);
-    const body = {};
-
-    /*
-      Axios.post('/api/users/login', body).then(response => {
-
-      })
-      */
   };
 
   return (
@@ -38,9 +29,9 @@ const loginView = () => {
         <div className="loginBox">
           <form onSubmit={onSubmitHandler}>
             <div className="loginLabel">아이디</div>
-            <Input placeholder="id" type="id" value={Id} onChange={onIdHandler} />
+            <Input placeholder="id" type="id" value={id} onChange={onIdHandler} />
             <div className="loginLabel">패스워드</div>
-            <Input placeholder="password" type="password" value={Password} onChange={onPasswordHandler} />
+            <Input placeholder="password" type="password" value={password} onChange={onPasswordHandler} />
             <div className="localLogin">
               <button className="localLoginBtn" type="submit">
                 로그인
@@ -50,7 +41,7 @@ const loginView = () => {
               </button>
             </div>
           </form>
-          <a className="gitHubLogin" href="#">
+          <a className="gitHubLogin" href={urlForGitHubOAuth + '?redirect=' + clientUrl}>
             Sign with GitHub
             <img className="gitHubMark" src={imgSrc} />
           </a>
@@ -61,26 +52,3 @@ const loginView = () => {
 };
 
 export default loginView;
-
-/*
-<div className="loginContainer">
-      <h1>이슈 트래커</h1>
-      <div className="loginBox">
-        <div>
-          아이디
-          <input id="id" type="text" />
-        </div>
-        <div>
-          비밀번호
-          <input id="password" type="password" />
-        </div>
-        <div>
-          <a href="#">로그인</a>
-          <a href="#">회원가입</a>
-        </div>
-        <div>
-          <a href="#">GitHub 회원가입</a>
-        </div>
-      </div>
-    </div>
-    */

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -6,7 +6,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = {
   // entry: 웹팩에게 어플리케이션이 어디서 시작하고 어디서부터 파일들을 묶을건지 시작점을 정해준다.
-  entry: ['./src/index.js'],
+  entry: ['babel-polyfill', './src/index.js'],
   // 현재 개발 모드에서 작업 중임을 알려줌.
   mode: 'development',
   // export한 JS 모듈이 어떻게 변환되는지 정의한다. 방법은 rules에 정의한 대로 이루어진다.
@@ -16,6 +16,23 @@ module.exports = {
         test: /\.(js|jsx)$/,
         exclude: '/node_modules/',
         loader: 'babel-loader',
+        options: {
+          presets: [
+            // 배열로 선언하면 babel이 컴파일 할 대상 브라우저도 지정 가능
+            [
+              '@babel/preset-env',
+              {
+                targets: {
+                  // 크롬 최종 버젼으로 부터 2개 버젼 https://github.com/browserslist/browserslist#queries
+                  browsers: ['last 2 chrome versions'],
+                },
+                debug: true,
+              },
+            ],
+            '@babel/preset-react',
+          ],
+          plugins: ['@babel/plugin-proposal-class-properties'],
+        },
       },
       {
         test: /\.(css|scss)$/,
@@ -46,17 +63,19 @@ module.exports = {
     // publicPath: '/dist/',
     filename: 'bundle.js',
   },
-  devtool: 'eval-cheap-source-map',
+  devtool: 'cheap-module-eval-source-map',
   // webpack-dev-server의 옵션을 설정
   devServer: {
     // 정적 파일 경로 설정
     contentBase: path.join(__dirname, 'dist'),
     port: 3000,
-    publicPath: '/',
     // devserver 에서만 핫로딩 가능하게
     hotOnly: true,
     open: true,
     historyApiFallback: true,
+    proxy: {
+      '/api': 'http://localhost:5000',
+    },
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -6,7 +6,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = {
   // entry: 웹팩에게 어플리케이션이 어디서 시작하고 어디서부터 파일들을 묶을건지 시작점을 정해준다.
-  entry: ['./src/index.js'],
+  entry: ['babel-polyfill', './src/index.js'],
   // 현재 개발 모드에서 작업 중임을 알려줌.
   mode: 'development',
   // export한 JS 모듈이 어떻게 변환되는지 정의한다. 방법은 rules에 정의한 대로 이루어진다.
@@ -16,6 +16,23 @@ module.exports = {
         test: /\.(js|jsx)$/,
         exclude: '/node_modules/',
         loader: 'babel-loader',
+        options: {
+          presets: [
+            // 배열로 선언하면 babel이 컴파일 할 대상 브라우저도 지정 가능
+            [
+              '@babel/preset-env',
+              {
+                targets: {
+                  // 크롬 최종 버젼으로 부터 2개 버젼 https://github.com/browserslist/browserslist#queries
+                  browsers: ['last 2 chrome versions'],
+                },
+                debug: true,
+              },
+            ],
+            '@babel/preset-react',
+          ],
+          plugins: ['@babel/plugin-proposal-class-properties'],
+        },
       },
       {
         test: /\.(css|scss)$/,

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -69,10 +69,12 @@ module.exports = {
     // 정적 파일 경로 설정
     contentBase: path.join(__dirname, 'dist'),
     port: 3000,
-    publicPath: '/',
     // devserver 에서만 핫로딩 가능하게
     hotOnly: true,
     open: true,
+    proxy: {
+      '/api': 'http://localhost:5000',
+    },
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),


### PR DESCRIPTION
### GitHub OAuth Login View완성
- chore : babel-polyfill 설정 추가
  - async await 호환을 위한 webpack babel-polyfill 설정 추가
- feat : axios 모듈 테스트
  - 서버와 통신을 위해 axios 모듈 추가
- feat : GitHub OAuth 연동 완료
  - webpack.config.js 충돌 해결
  - GitHub 인증 후 클라이언트로 돌아오기 위해 redirect 주소를 a 링크에 추가
  - axios 대신 a 링크를 통해 GitHub OAuth 처리
  - 주석 제거
- fix : 충돌 해결
  - Merge branch 'client-loginView' of https://github.com/boostcamp-2020/IssueTracker-04 into client-loginView