### PR TITLE
[SERVER-OAUTH] GitHub Oauth API 서버 완성

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -53,7 +53,7 @@ app.use(passport.session());
 passportConfig();
 
 models.sequelize
-  .sync()
+  .sync({ logging: false })
   .then(() => {
     console.log('DB 연결 성공');
   })

--- a/server/config/statusCode.js
+++ b/server/config/statusCode.js
@@ -1,0 +1,5 @@
+const statusCode = {
+  FORBIDDEN: 403,
+};
+
+exports.statusCode = statusCode;

--- a/server/routes/auth/github.js
+++ b/server/routes/auth/github.js
@@ -5,6 +5,10 @@ const auth = require('../../services/auth/github');
 
 router.get('/api/auth/github/', auth.gitLoginCheck);
 
-router.get('/api/auth/github/callback', auth.gitLoginCallback);
+router.get(
+  '/api/auth/github/callback',
+  auth.gitLoginCallback,
+  auth.gitRedirect
+);
 
 module.exports = router;

--- a/server/routes/auth/github.js
+++ b/server/routes/auth/github.js
@@ -1,14 +1,14 @@
 const express = require('express');
 const router = express.Router();
 
-const auth = require('../../services/auth/github');
+const gitAuth = require('../../services/auth/github');
 
-router.get('/api/auth/github/', auth.gitLoginCheck);
+router.get('/api/auth/github/', gitAuth.gitLoginCheck);
 
 router.get(
   '/api/auth/github/callback',
-  auth.gitLoginCallback,
-  auth.gitRedirect
+  gitAuth.gitLoginCallback,
+  gitAuth.gitRedirect
 );
 
 module.exports = router;

--- a/server/routes/users/users.js
+++ b/server/routes/users/users.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 const userModel = require('../../models').user;
+const auth = require('../../services/auth');
 
 router.post('/api/users/signup', async (req, res, next) => {
   // const { id, pw, name} = req.query;
@@ -49,11 +50,13 @@ router.get('/api/users/user:userNo', async (req, res, next) => {
   }
 });
 
-router.get('/api/users/logout', function (req, res) {
+router.get('/api/users/logout', auth.isLogged, function (req, res) {
   req.logout();
   res.clearCookie('connect.sid');
-  console.log(req.user);
-  res.status(200).json({ success: true, message: '로그아웃 성공' });
+  if (!req.user)
+    return res.status(200).json({ success: true, message: '로그아웃 성공' });
+  else
+    return res.status(400).json({ success: false, message: '로그아웃 실패' });
 });
 
 module.exports = router;

--- a/server/routes/users/users.js
+++ b/server/routes/users/users.js
@@ -52,6 +52,7 @@ router.get('/api/users/user:userNo', async (req, res, next) => {
 router.get('/api/users/logout', function (req, res) {
   req.logout();
   res.clearCookie('connect.sid');
+  console.log(req.user);
   res.status(200).json({ success: true, message: '로그아웃 성공' });
 });
 

--- a/server/services/auth/index.js
+++ b/server/services/auth/index.js
@@ -1,0 +1,19 @@
+const { statusCode } = require('../../config/statusCode');
+
+exports.isLogged = (req, res, next) => {
+  if (!req.user) {
+    return res
+      .status(statusCode.FORBIDDEN)
+      .json({ success: false, message: '로그인 하지 않은 사용자' });
+  }
+  next();
+};
+
+exports.isNotLogged = (req, res, next) => {
+  if (req.user) {
+    return res
+      .status(statusCode.FORBIDDEN)
+      .json({ success: false, message: '로그인 된 사용자' });
+  }
+  next();
+};


### PR DESCRIPTION
###  GitHub Oauth API 서버 완성

- feat : GitHub Oauth API 완성
  - 클라이언트 페이지로 redirect 하기 위한 gitRedirect 미들웨어 추가
  - query로 받은 redirect 주소를 req.session에 저장

- refactor : services auth 비즈니스 로직 리팩토링
  - 인증 부분의 코드 가독성을 위해 createSession 분리
  - createSession 메소드와 관련된 메소드 예외처리
  - sequelize sync의 logging 출력하지 않게 설정

- feat : isLogged, isNotLogged 미들웨어 추가
  - 라우터 접근 제한을 위한 isLogged, isNotLogged 미들웨어 추가
  - status code 관리를 위한 config/statusCode.js 파일 추가